### PR TITLE
Handle Prisma connection failures gracefully

### DIFF
--- a/app/(protected)/orders/hooks/use-orders.ts
+++ b/app/(protected)/orders/hooks/use-orders.ts
@@ -3,11 +3,25 @@
 import useSWR from "swr";
 import { ordersSchema, type Order } from "@/lib/schemas/order";
 import { useSearchParams } from "next/navigation";
+import { DATABASE_ERROR_MESSAGE } from "@/lib/errors";
 
 const fetcher = async (url: string): Promise<Order[]> => {
-  const response = await fetch(url);
-  const data = await response.json();
-  return ordersSchema.parse(data);
+  try {
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      const data = await response.json().catch(() => null);
+      const message = data?.error || DATABASE_ERROR_MESSAGE;
+      throw new Error(message);
+    }
+
+    const data = await response.json();
+    return ordersSchema.parse(data);
+  } catch (err) {
+    throw new Error(
+      err instanceof Error ? err.message : DATABASE_ERROR_MESSAGE
+    );
+  }
 };
 
 export const useOrders = () => {

--- a/app/(protected)/orders/page.tsx
+++ b/app/(protected)/orders/page.tsx
@@ -11,12 +11,13 @@ import {
 import OrderCard from "./_components/order-card";
 import { useOrders } from "./hooks/use-orders";
 import { Skeleton } from "@/app/_components/ui/skeleton";
+import ErrorMessage from "@/app/_components/error-message";
 // import { useSession } from "next-auth/react";
 // import { redirect } from "next/navigation";
 import { OrdersFilterBar } from "./_components/orders-filter-bar";
 
 const OrdersPage = () => {
-  const { orders, isLoading } = useOrders();
+  const { orders, isLoading, isError } = useOrders();
   // const { data: session } = useSession();
 
   // if (!session?.user) {
@@ -35,6 +36,8 @@ const OrdersPage = () => {
       <PageContent>
         {isLoading ? (
           <Skeleton className="h-[200px] w-[200px]" />
+        ) : isError ? (
+          <ErrorMessage message="Não foi possível carregar os pedidos" />
         ) : orders.length === 0 ? (
           <p className="text-sm text-muted-foreground">
             Nenhum pedido encontrado hoje.

--- a/app/_actions/cancel-order.ts
+++ b/app/_actions/cancel-order.ts
@@ -2,12 +2,14 @@
 
 import { db } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
-import { OrderStatus } from "@prisma/client";
+import { OrderStatus, Prisma } from "@prisma/client";
+import { DATABASE_ERROR_MESSAGE } from "@/lib/errors";
 
 export async function cancelOrder(orderId: number) {
-  const order = await db.order.findUnique({
-    where: { id: orderId },
-  });
+  try {
+    const order = await db.order.findUnique({
+      where: { id: orderId },
+    });
 
   if (!order) {
     throw new Error("Pedido não encontrado");
@@ -17,12 +19,22 @@ export async function cancelOrder(orderId: number) {
     throw new Error("Somente pedidos pendentes podem ser cancelados.");
   }
 
-  await db.order.update({
-    where: { id: orderId },
-    data: {
-      status: OrderStatus.PAYMENT_FAILED,
-    },
-  });
+    await db.order.update({
+      where: { id: orderId },
+      data: {
+        status: OrderStatus.PAYMENT_FAILED,
+      },
+    });
 
-  revalidatePath("/orders");
+    revalidatePath("/orders");
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError ||
+      error instanceof Prisma.PrismaClientInitializationError ||
+      error instanceof Prisma.PrismaClientRustPanicError
+    ) {
+      throw new Error(DATABASE_ERROR_MESSAGE);
+    }
+    throw error;
+  }
 }

--- a/app/_actions/get-all-salgados-pizzas.ts
+++ b/app/_actions/get-all-salgados-pizzas.ts
@@ -1,23 +1,36 @@
 "use server";
 
 import { db } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+import { DATABASE_ERROR_MESSAGE } from "@/lib/errors";
 
 export async function getAllSalgadosAndPizzas() {
-  const products = await db.product.findMany({
-    where: {
-      menuCategory: {
-        name: {
-          in: ["Salgados", "Pizza"],
+  try {
+    const products = await db.product.findMany({
+      where: {
+        menuCategory: {
+          name: {
+            in: ["Salgados", "Pizza"],
+          },
         },
       },
-    },
-    include: {
-      menuCategory: true,
-    },
-    orderBy: {
-      name: "asc",
-    },
-  });
+      include: {
+        menuCategory: true,
+      },
+      orderBy: {
+        name: "asc",
+      },
+    });
 
-  return products;
+    return products;
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError ||
+      error instanceof Prisma.PrismaClientInitializationError ||
+      error instanceof Prisma.PrismaClientRustPanicError
+    ) {
+      throw new Error(DATABASE_ERROR_MESSAGE);
+    }
+    throw error;
+  }
 }

--- a/app/_actions/get-cheaper-products.ts
+++ b/app/_actions/get-cheaper-products.ts
@@ -2,17 +2,30 @@
 
 import type { Product } from "@prisma/client";
 import { db } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+import { DATABASE_ERROR_MESSAGE } from "@/lib/errors";
 
 export async function getCheaperProducts(): Promise<Product[]> {
-  return db.product.findMany({
-    where: {
-      price: {
-        gte: 3000, // R$30
-        lte: 10000, // R$100
+  try {
+    return await db.product.findMany({
+      where: {
+        price: {
+          gte: 3000, // R$30
+          lte: 10000, // R$100
+        },
       },
-    },
-    orderBy: {
-      price: "asc",
-    },
-  });
+      orderBy: {
+        price: "asc",
+      },
+    });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError ||
+      error instanceof Prisma.PrismaClientInitializationError ||
+      error instanceof Prisma.PrismaClientRustPanicError
+    ) {
+      throw new Error(DATABASE_ERROR_MESSAGE);
+    }
+    throw error;
+  }
 }

--- a/app/_actions/get-favorite-products.ts
+++ b/app/_actions/get-favorite-products.ts
@@ -1,17 +1,30 @@
 "use server";
 
 import { db } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+import { DATABASE_ERROR_MESSAGE } from "@/lib/errors";
 
 export async function getFavoriteProducts(userId: string) {
-  const products = await db.product.findMany({
-    where: {
-      usersWhoFavorited: {
-        some: {
-          userId,
+  try {
+    const products = await db.product.findMany({
+      where: {
+        usersWhoFavorited: {
+          some: {
+            userId,
+          },
         },
       },
-    },
-  });
+    });
 
-  return products;
+    return products;
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError ||
+      error instanceof Prisma.PrismaClientInitializationError ||
+      error instanceof Prisma.PrismaClientRustPanicError
+    ) {
+      throw new Error(DATABASE_ERROR_MESSAGE);
+    }
+    throw error;
+  }
 }

--- a/app/_actions/get-menu-categories.ts
+++ b/app/_actions/get-menu-categories.ts
@@ -1,17 +1,30 @@
 "use server";
 
 import { db } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+import { DATABASE_ERROR_MESSAGE } from "@/lib/errors";
 
 export const getMenuCategories = async () => {
-  const categories = await db.menuCategory.findMany({
-    select: {
-      id: true,
-      name: true,
-    },
-    orderBy: {
-      name: "asc",
-    },
-  });
+  try {
+    const categories = await db.menuCategory.findMany({
+      select: {
+        id: true,
+        name: true,
+      },
+      orderBy: {
+        name: "asc",
+      },
+    });
 
-  return categories;
+    return categories;
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError ||
+      error instanceof Prisma.PrismaClientInitializationError ||
+      error instanceof Prisma.PrismaClientRustPanicError
+    ) {
+      throw new Error(DATABASE_ERROR_MESSAGE);
+    }
+    throw error;
+  }
 };

--- a/app/_actions/get-most-ordered-products-by-user.ts
+++ b/app/_actions/get-most-ordered-products-by-user.ts
@@ -3,15 +3,18 @@
 import type { Product } from "@prisma/client";
 
 import { db } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+import { DATABASE_ERROR_MESSAGE } from "@/lib/errors";
 
 export async function getTop10MostOrderedProductsByUser(
   userId: string,
 ): Promise<Product[]> {
-  const result = await db.orderProduct.groupBy({
-    by: ["productId"],
-    where: {
-      order: {
-        userId,
+  try {
+    const result = await db.orderProduct.groupBy({
+      by: ["productId"],
+      where: {
+        order: {
+          userId,
       },
     },
     _count: {
@@ -25,17 +28,26 @@ export async function getTop10MostOrderedProductsByUser(
     take: 10,
   });
 
-  const productIds = result.map((item) => item.productId);
+    const productIds = result.map((item) => item.productId);
 
-  const products = await db.product.findMany({
-    where: {
-      id: {
-        in: productIds,
+    const products = await db.product.findMany({
+      where: {
+        id: {
+          in: productIds,
+        },
       },
-    },
-  });
+    });
 
-  // Garantir a ordem correta (porque `findMany` pode vir fora de ordem)
-  const productMap = new Map(products.map((p) => [p.id, p]));
-  return productIds.map((id) => productMap.get(id)!);
+    const productMap = new Map(products.map((p) => [p.id, p]));
+    return productIds.map((id) => productMap.get(id)!);
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError ||
+      error instanceof Prisma.PrismaClientInitializationError ||
+      error instanceof Prisma.PrismaClientRustPanicError
+    ) {
+      throw new Error(DATABASE_ERROR_MESSAGE);
+    }
+    throw error;
+  }
 }

--- a/app/_actions/get-most-ordered-products.ts
+++ b/app/_actions/get-most-ordered-products.ts
@@ -2,14 +2,27 @@
 
 import type { Product } from "@prisma/client";
 import { db } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+import { DATABASE_ERROR_MESSAGE } from "@/lib/errors";
 
 export async function getMostOrderedProducts(): Promise<Product[]> {
-  return db.product.findMany({
-    orderBy: {
-      orderProducts: {
-        _count: "desc",
+  try {
+    return await db.product.findMany({
+      orderBy: {
+        orderProducts: {
+          _count: "desc",
+        },
       },
-    },
-    take: 10,
-  });
+      take: 10,
+    });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError ||
+      error instanceof Prisma.PrismaClientInitializationError ||
+      error instanceof Prisma.PrismaClientRustPanicError
+    ) {
+      throw new Error(DATABASE_ERROR_MESSAGE);
+    }
+    throw error;
+  }
 }

--- a/app/_actions/get-order-product.ts
+++ b/app/_actions/get-order-product.ts
@@ -1,19 +1,32 @@
 "use server";
 
 import { db } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+import { DATABASE_ERROR_MESSAGE } from "@/lib/errors";
 
 export const getOrderProduct = async (userId: string) => {
-  const orderProducts = await db.orderProduct.findMany({
-    where: {
-      order: {
-        userId: userId,
+  try {
+    const orderProducts = await db.orderProduct.findMany({
+      where: {
+        order: {
+          userId: userId,
+        },
       },
-    },
-    include: {
-      product: true,
-    },
-    take: 10,
-  });
+      include: {
+        product: true,
+      },
+      take: 10,
+    });
 
-  return orderProducts;
+    return orderProducts;
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError ||
+      error instanceof Prisma.PrismaClientInitializationError ||
+      error instanceof Prisma.PrismaClientRustPanicError
+    ) {
+      throw new Error(DATABASE_ERROR_MESSAGE);
+    }
+    throw error;
+  }
 };

--- a/app/_actions/get-products-home.ts
+++ b/app/_actions/get-products-home.ts
@@ -2,18 +2,31 @@
 
 import type { Product } from "@prisma/client";
 import { db } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+import { DATABASE_ERROR_MESSAGE } from "@/lib/errors";
 
 export async function getHomeProducts(): Promise<Product[]> {
-  return db.product.findMany({
-    where: {
-      menuCategory: {
-        name: {
-          in: ["Salgados", "Pizza"],
+  try {
+    return await db.product.findMany({
+      where: {
+        menuCategory: {
+          name: {
+            in: ["Salgados", "Pizza"],
+          },
         },
       },
-    },
-    orderBy: {
-      name: "asc",
-    },
-  });
+      orderBy: {
+        name: "asc",
+      },
+    });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError ||
+      error instanceof Prisma.PrismaClientInitializationError ||
+      error instanceof Prisma.PrismaClientRustPanicError
+    ) {
+      throw new Error(DATABASE_ERROR_MESSAGE);
+    }
+    throw error;
+  }
 }

--- a/app/_actions/get-restaurant-by-slug.ts
+++ b/app/_actions/get-restaurant-by-slug.ts
@@ -1,9 +1,22 @@
 "use server";
 
 import { db } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+import { DATABASE_ERROR_MESSAGE } from "@/lib/errors";
 
 export const getRestaurantBySlug = async (slug: string) => {
-  const restaurant = await db.restaurant.findUnique({ where: { slug } });
+  try {
+    const restaurant = await db.restaurant.findUnique({ where: { slug } });
 
-  return restaurant;
+    return restaurant;
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError ||
+      error instanceof Prisma.PrismaClientInitializationError ||
+      error instanceof Prisma.PrismaClientRustPanicError
+    ) {
+      throw new Error(DATABASE_ERROR_MESSAGE);
+    }
+    throw error;
+  }
 };

--- a/app/_actions/get-student-by-class.ts
+++ b/app/_actions/get-student-by-class.ts
@@ -1,22 +1,35 @@
 "use server";
 
 import { db } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+import { DATABASE_ERROR_MESSAGE } from "@/lib/errors";
 
 export const getStudentByClass = async (serie: string) => {
-  const students = await db.student.findMany({
-    where: {
-      serie: {
-        name: serie,
+  try {
+    const students = await db.student.findMany({
+      where: {
+        serie: {
+          name: serie,
+        },
       },
-    },
-    select: {
-      id: true,
-      name: true,
-    },
-  });
+      select: {
+        id: true,
+        name: true,
+      },
+    });
 
-  return students.map((student) => ({
-    id: student.id.toString(), // garante que seja string
-    student: student.name, // renomeia para "student"
-  }));
+    return students.map((student) => ({
+      id: student.id.toString(), // garante que seja string
+      student: student.name, // renomeia para "student"
+    }));
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError ||
+      error instanceof Prisma.PrismaClientInitializationError ||
+      error instanceof Prisma.PrismaClientRustPanicError
+    ) {
+      throw new Error(DATABASE_ERROR_MESSAGE);
+    }
+    throw error;
+  }
 };

--- a/app/_actions/search.ts
+++ b/app/_actions/search.ts
@@ -1,16 +1,29 @@
 "use server";
 
 import { db } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+import { DATABASE_ERROR_MESSAGE } from "@/lib/errors";
 
 export const searchForProducts = async (search: string) => {
-  const products = db.product.findMany({
-    where: {
-      name: {
-        contains: search,
-        mode: "insensitive",
+  try {
+    const products = await db.product.findMany({
+      where: {
+        name: {
+          contains: search,
+          mode: "insensitive",
+        },
       },
-    },
-  });
+    });
 
-  return products;
+    return products;
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError ||
+      error instanceof Prisma.PrismaClientInitializationError ||
+      error instanceof Prisma.PrismaClientRustPanicError
+    ) {
+      throw new Error(DATABASE_ERROR_MESSAGE);
+    }
+    throw error;
+  }
 };

--- a/app/_actions/update-order-status.ts
+++ b/app/_actions/update-order-status.ts
@@ -2,12 +2,14 @@
 
 import { db } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
-import { OrderStatus } from "@prisma/client";
+import { OrderStatus, Prisma } from "@prisma/client";
+import { DATABASE_ERROR_MESSAGE } from "@/lib/errors";
 
 export async function updateOrderStatus(orderId: number) {
-  const order = await db.order.findUnique({
-    where: { id: orderId },
-  });
+  try {
+    const order = await db.order.findUnique({
+      where: { id: orderId },
+    });
 
   if (!order) {
     throw new Error("Pedido não encontrado");
@@ -33,14 +35,24 @@ export async function updateOrderStatus(orderId: number) {
       throw new Error("Status desconhecido");
   }
 
-  if (nextStatus) {
-    await db.order.update({
-      where: { id: orderId },
-      data: { status: nextStatus },
-    });
+    if (nextStatus) {
+      await db.order.update({
+        where: { id: orderId },
+        data: { status: nextStatus },
+      });
 
-    revalidatePath("/orders");
+      revalidatePath("/orders");
+    }
+
+    return nextStatus;
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError ||
+      error instanceof Prisma.PrismaClientInitializationError ||
+      error instanceof Prisma.PrismaClientRustPanicError
+    ) {
+      throw new Error(DATABASE_ERROR_MESSAGE);
+    }
+    throw error;
   }
-
-  return nextStatus;
 }

--- a/app/_actions/upsert-product/index.ts
+++ b/app/_actions/upsert-product/index.ts
@@ -3,37 +3,49 @@
 import { db } from "@/lib/prisma";
 import { upsertProductSchema, type UpsertProductSchema } from "./schema";
 import { revalidatePath } from "next/cache";
+import { Prisma } from "@prisma/client";
+import { DATABASE_ERROR_MESSAGE } from "@/lib/errors";
 
 export const upsertProduct = async (data: UpsertProductSchema) => {
   upsertProductSchema.parse(data);
-
-  await db.product.upsert({
-    where: { id: data.id! },
-    create: {
-      id: data.id,
-      name: data.name,
-      price: data.priceInCents,
-      description: data.description,
-      imageUrl: data.imageUrl,
-      menuCategory: {
-        connect: { id: data.menuCategoryId },
+  try {
+    await db.product.upsert({
+      where: { id: data.id! },
+      create: {
+        id: data.id,
+        name: data.name,
+        price: data.priceInCents,
+        description: data.description,
+        imageUrl: data.imageUrl,
+        menuCategory: {
+          connect: { id: data.menuCategoryId },
+        },
+        restaurant: {
+          connect: { id: data.restaurantId }, // atualizado aqui
+        },
       },
-      restaurant: {
-        connect: { id: data.restaurantId }, // atualizado aqui
+      update: {
+        name: data.name,
+        price: data.priceInCents,
+        description: data.description,
+        imageUrl: data.imageUrl,
+        menuCategory: {
+          connect: { id: data.menuCategoryId },
+        },
+        restaurant: {
+          connect: { id: data.restaurantId }, // e aqui
+        },
       },
-    },
-    update: {
-      name: data.name,
-      price: data.priceInCents,
-      description: data.description,
-      imageUrl: data.imageUrl,
-      menuCategory: {
-        connect: { id: data.menuCategoryId },
-      },
-      restaurant: {
-        connect: { id: data.restaurantId }, // e aqui
-      },
-    },
-  });
-  revalidatePath("/products");
+    });
+    revalidatePath("/products");
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError ||
+      error instanceof Prisma.PrismaClientInitializationError ||
+      error instanceof Prisma.PrismaClientRustPanicError
+    ) {
+      throw new Error(DATABASE_ERROR_MESSAGE);
+    }
+    throw error;
+  }
 };

--- a/app/_components/error-message.tsx
+++ b/app/_components/error-message.tsx
@@ -1,0 +1,14 @@
+interface ErrorMessageProps {
+  message: string;
+}
+
+const ErrorMessage = ({ message }: ErrorMessageProps) => {
+  return (
+    <p className="text-sm text-destructive-foreground bg-destructive/10 p-2 rounded-md">
+      {message}
+    </p>
+  );
+};
+
+export default ErrorMessage;
+

--- a/app/_components/products-cheap-good.tsx
+++ b/app/_components/products-cheap-good.tsx
@@ -2,6 +2,7 @@ import type { Product } from "@prisma/client";
 import ProductItem from "./product-item";
 import { getCheaperProducts } from "@/app/_actions/get-cheaper-products";
 import { getTop10MostOrderedProductsByUser } from "@/app/_actions/get-most-ordered-products-by-user";
+import ErrorMessage from "./error-message";
 
 interface Props {
   title: string;
@@ -9,20 +10,26 @@ interface Props {
 }
 
 const ProductsCheapGood = async ({ title, userId }: Props) => {
-  const products = userId
-    ? await getTop10MostOrderedProductsByUser(userId)
-    : await getCheaperProducts();
+  try {
+    const products = userId
+      ? await getTop10MostOrderedProductsByUser(userId)
+      : await getCheaperProducts();
 
-  return (
-    <div className="flex flex-col gap-4">
-      <h3 className="text-base font-semibold">{title}</h3>
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
-        {products.map((product: Product) => (
-          <ProductItem key={product.id} product={product} />
-        ))}
+    return (
+      <div className="flex flex-col gap-4">
+        <h3 className="text-base font-semibold">{title}</h3>
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+          {products.map((product: Product) => (
+            <ProductItem key={product.id} product={product} />
+          ))}
+        </div>
       </div>
-    </div>
-  );
+    );
+  } catch (error) {
+    return (
+      <ErrorMessage message="Não foi possível carregar os produtos" />
+    );
+  }
 };
 
 export default ProductsCheapGood;

--- a/app/_components/products-home.tsx
+++ b/app/_components/products-home.tsx
@@ -1,24 +1,31 @@
 import type { Product } from "@prisma/client";
 import ProductItem from "./product-item";
 import { getHomeProducts } from "@/app/_actions/get-products-home";
+import ErrorMessage from "./error-message";
 
 interface ProductsHomeProps {
   title: string;
 }
 
 const ProductsHome = async ({ title }: ProductsHomeProps) => {
-  const products = await getHomeProducts();
+  try {
+    const products = await getHomeProducts();
 
-  return (
-    <div className="flex flex-col gap-4">
-      <h3 className="text-base font-semibold">{title}</h3>
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
-        {products.map((product: Product) => (
-          <ProductItem key={product.id} product={product} />
-        ))}
+    return (
+      <div className="flex flex-col gap-4">
+        <h3 className="text-base font-semibold">{title}</h3>
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+          {products.map((product: Product) => (
+            <ProductItem key={product.id} product={product} />
+          ))}
+        </div>
       </div>
-    </div>
-  );
+    );
+  } catch (err) {
+    return (
+      <ErrorMessage message="Não foi possível carregar os produtos" />
+    );
+  }
 };
 
 export default ProductsHome;

--- a/app/_components/products-more-orders.tsx
+++ b/app/_components/products-more-orders.tsx
@@ -1,24 +1,31 @@
 import type { Product } from "@prisma/client";
 import ProductItem from "./product-item";
 import { getMostOrderedProducts } from "@/app/_actions/get-most-ordered-products";
+import ErrorMessage from "./error-message";
 
 interface Props {
   title: string;
 }
 
 const ProductsMoreOrders = async ({ title }: Props) => {
-  const products = await getMostOrderedProducts();
+  try {
+    const products = await getMostOrderedProducts();
 
-  return (
-    <div className="mb-5 flex flex-col gap-4">
-      <h3 className="text-base font-semibold">{title}</h3>
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
-        {products.map((product: Product) => (
-          <ProductItem key={product.id} product={product} />
-        ))}
+    return (
+      <div className="mb-5 flex flex-col gap-4">
+        <h3 className="text-base font-semibold">{title}</h3>
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+          {products.map((product: Product) => (
+            <ProductItem key={product.id} product={product} />
+          ))}
+        </div>
       </div>
-    </div>
-  );
+    );
+  } catch (error) {
+    return (
+      <ErrorMessage message="Não foi possível carregar os produtos" />
+    );
+  }
 };
 
 export default ProductsMoreOrders;

--- a/app/api/update-order-status/route.ts
+++ b/app/api/update-order-status/route.ts
@@ -1,5 +1,6 @@
 import { updateOrderStatus } from "@/app/_actions/update-order-status";
 import { NextResponse } from "next/server";
+import { DATABASE_ERROR_MESSAGE } from "@/lib/errors";
 
 export async function POST(req: Request) {
   const formData = await req.formData();
@@ -19,7 +20,7 @@ export async function POST(req: Request) {
   } catch (error) {
     console.log(error);
     return NextResponse.json(
-      { error: "Erro ao atualizar status" },
+      { error: DATABASE_ERROR_MESSAGE },
       { status: 500 },
     );
   }

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -2,6 +2,7 @@ import { db } from "@/lib/prisma";
 // import { buffer } from "micro";
 import Stripe from "stripe";
 import { NextResponse } from "next/server";
+import { DATABASE_ERROR_MESSAGE } from "@/lib/errors";
 
 // Inicializa o Stripe com sua chave secreta
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
@@ -43,10 +44,18 @@ export async function POST(req: Request) {
     const orderId = session.metadata?.orderId;
 
     if (orderId) {
-      await db.order.update({
-        where: { id: parseInt(orderId) },
-        data: { status: "PAYMENT_CONFIRMED" },
-      });
+      try {
+        await db.order.update({
+          where: { id: parseInt(orderId) },
+          data: { status: "PAYMENT_CONFIRMED" },
+        });
+      } catch (error) {
+        console.error(error);
+        return NextResponse.json(
+          { error: DATABASE_ERROR_MESSAGE },
+          { status: 500 },
+        );
+      }
     }
   }
 
@@ -55,10 +64,18 @@ export async function POST(req: Request) {
     const orderId = session.metadata?.orderId;
 
     if (orderId) {
-      await db.order.update({
-        where: { id: parseInt(orderId) },
-        data: { status: "PAYMENT_FAILED" },
-      });
+      try {
+        await db.order.update({
+          where: { id: parseInt(orderId) },
+          data: { status: "PAYMENT_FAILED" },
+        });
+      } catch (error) {
+        console.error(error);
+        return NextResponse.json(
+          { error: DATABASE_ERROR_MESSAGE },
+          { status: 500 },
+        );
+      }
     }
   }
 

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,0 +1,3 @@
+export const DATABASE_ERROR_MESSAGE =
+  "Erro ao conectar com o banco de dados. Tente novamente mais tarde.";
+


### PR DESCRIPTION
## Summary
- add `ErrorMessage` component and database error constant
- catch database connection errors in API routes and Prisma actions
- show fallback message in homepage product sections
- surface order API errors in SWR hook and orders page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e6b84b90832cbb3a1bc2d142f29d