### PR TITLE
Fix NextAuth session typing

### DIFF
--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -1,6 +1,5 @@
 import { getFirstName } from "@/helpers/firts-name";
 import { authOptions } from "@/lib/auth";
-import { Session } from "next-auth";
 
 import { formatDateBRWithTime } from "@/helpers/format-date-br";
 import ProductsCheapGood from "@/app/_components/products-cheap-good";
@@ -15,7 +14,7 @@ import Search from "@/app/_components/search";
 import { getServerSession } from "next-auth/next";
 
 const HomePage = async () => {
-  const session = (await getServerSession(authOptions)) as Session | null;
+  const session = await getServerSession(authOptions);
   const userId = session?.user?.id ?? null;
   const dataAtual = new Date();
 

--- a/next-auth.d.ts
+++ b/next-auth.d.ts
@@ -1,9 +1,16 @@
-import type { DefaultSession } from "next-auth";
+import NextAuth from "next-auth";
 
 declare module "next-auth" {
   interface Session {
     user: {
-      id?: string;
-    } & DefaultSession["user"];
+      id: string;
+      name?: string | null;
+      email?: string | null;
+      image?: string | null;
+    };
+  }
+
+  interface User {
+    id: string;
   }
 }


### PR DESCRIPTION
## Summary
- update custom typings for next-auth session to include `id`
- remove unnecessary type cast on the home page

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'react')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684752233220832c8a6834fac751c691