### PR TITLE
Fix NextAuth integration

### DIFF
--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -11,7 +11,7 @@ import BannerPromo from "@/app/_components/banner-promo";
 import Footer from "@/app/_components/footer";
 import Header from "@/app/_components/header";
 import Search from "@/app/_components/search";
-import { getServerSession } from "next-auth/next";
+import { getServerSession } from "next-auth";
 
 const HomePage = async () => {
   const session = (await getServerSession(authOptions)) as Session | null;

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -1,5 +1,5 @@
 import { authOptions } from "@/app/_lib/auth";
-import { getServerSession } from "next-auth/next";
+import { getServerSession } from "next-auth";
 import type { Session } from "next-auth";
 import { redirect } from "next/navigation";
 

--- a/app/(protected)/products/page.tsx
+++ b/app/(protected)/products/page.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/app/_components/ui/page-container";
 import { PageDescription } from "@/app/_components/ui/page-container";
 import { authOptions } from "@/app/_lib/auth";
-import { getServerSession } from "next-auth/next";
+import { getServerSession } from "next-auth";
 import type { Session } from "next-auth";
 import { redirect } from "next/navigation";
 import AddProductDialog from "./_components/add-product-dialog";

--- a/app/(protected)/students/page.tsx
+++ b/app/(protected)/students/page.tsx
@@ -8,7 +8,7 @@ import {
   PageActions,
 } from "@/app/_components/ui/page-container";
 import { Button } from "@/app/_components/ui/button";
-import { getServerSession } from "next-auth/next";
+import { getServerSession } from "next-auth";
 import type { Session } from "next-auth";
 import { redirect } from "next/navigation";
 import { db } from "@/app/_lib/prisma";

--- a/app/_lib/auth.ts
+++ b/app/_lib/auth.ts
@@ -1,5 +1,5 @@
 import { PrismaAdapter } from "@next-auth/prisma-adapter";
-import { AuthOptions } from "next-auth";
+import { AuthOptions, Session, User } from "next-auth";
 import { db } from "./prisma";
 import GoogleProvider from "next-auth/providers/google";
 import { Adapter } from "next-auth/adapters";
@@ -13,7 +13,7 @@ export const authOptions: AuthOptions = {
     }),
   ],
   callbacks: {
-    async session({ session, user }) {
+    async session({ session, user }: { session: Session; user: User }): Promise<Session> {
       session.user = { ...session.user, id: user.id };
       return session;
     },

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,5 +1,5 @@
 // app/api/auth/[...nextauth]/route.ts
-import NextAuth from "next-auth/next";
+import NextAuth from "next-auth";
 import { authOptions } from "@/app/_lib/auth";
 
 const handler = NextAuth(authOptions);

--- a/app/my-orders/page.tsx
+++ b/app/my-orders/page.tsx
@@ -1,6 +1,6 @@
 import { authOptions } from "@/app/_lib/auth";
 import { db } from "@/app/_lib/prisma";
-import { getServerSession } from "next-auth/next";
+import { getServerSession } from "next-auth";
 import type { Session } from "next-auth";
 import { redirect } from "next/navigation";
 import Header from "../_components/header";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
     "incremental": true,
     "types": [
       "react",
-      "react-dom"
+      "react-dom",
+      "next-auth"
     ],
     "plugins": [
       {


### PR DESCRIPTION
## Summary
- update NextAuth route handler
- ensure session callback uses correct types
- switch `getServerSession` imports to `next-auth`
- include next-auth types in TypeScript config

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684847f457c0832caf081d5b35aa069f